### PR TITLE
Add facetime call support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ your Mac. This is mostly useful for a desktop computer that is always on.
 * Set your volume.
 * Toggle Do Not Disturb mode on or off.
 * Set the audio device used for input or output.
+* Call someone on facetime
 
 ## Setup
 
@@ -62,6 +63,7 @@ These are the endpoints you can hit to do things.
     POST /volume/:level - Level: 0-100
     POST /dnd/:state - State: on or off
     POST /audiodevice/:port/:device - Port: input or output, Device: name of device
+    POST /facetime/:phonenumber - Phonenumber: ID of called person (phone number or email address)
 
 ## Contributions
 

--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ var brightness = path.resolve(__dirname, 'bin', 'brightness')
 var volume = path.resolve(__dirname, 'bin', 'volume')
 var audiodevice = path.resolve(__dirname, 'bin', 'audiodevice')
 var dnd = path.resolve(__dirname, 'bin', 'dnd')
+var facetime = path.resolve(__dirname, 'bin', 'facetime')
 
 var app = express()
 app.use(bodyParser.urlencoded({ extended: false }))
@@ -65,6 +66,13 @@ app.post('/audiodevice/:port/:device', function(req, res){
   port = req.params.port
   device = req.params.device
   exec(`${audiodevice} ${port} "${device}"`, function(error, stdout, stderr){
+    res.send('OK')
+  })
+})
+
+app.post('/facetime/:phonenumber', function(req, res){
+  phonenumber = req.params.phonenumber
+  exec(`${facetime} "${phonenumber}"`, function(error, stdout, stderr){
     res.send('OK')
   })
 })

--- a/bin/facetime
+++ b/bin/facetime
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+osascript <<EOD
+    do shell script "open facetime://" & quoted form of "$1"
+
+    tell application "System Events"
+    	repeat while not (second button of window 1 of application process "FaceTime" exists)
+    		delay 1
+    	end repeat
+    	click second button of window 1 of application process "FaceTime"
+    end tell
+EOD

--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,7 @@
         <p><span class="method">POST</span> /volume/:level - Level: 0-100</p>
         <p><span class="method">POST</span> /dnd/:state - State: on or off</p>
         <p><span class="method">POST</span> /audiodevice/:port/:device - Port: input or output, Device: device name</p>
+        <p><span class="method">POST</span> /facetime/:phonenumber - ID of called person (phone number or email address)</p>
       </div>
 
       <div class="footer">


### PR DESCRIPTION
Hello,
This is my first PR, I hope everything is done right

I wanted to add the support of calling someone on facetime.
I use it to call myself when I want to have a look on my home from afar but it can also be used to call anyone else from any automation.

To be able to work, you have to whitelist "System Events" in the Security > Accessibility preferences panel of macOS. A prompt will probably lead the user to the panel the first time the script is tried. I don't know if it's worth mentioning in the doc.